### PR TITLE
Fix OIDC publish by clearing conflicting auth token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
           npx semantic-release
       - name: Publish
         working-directory: ./
+        env:
+          NODE_AUTH_TOKEN: ''
         run: |
+          rm -f "$NPM_CONFIG_USERCONFIG"
           git config --global user.email "nkmr.git@gmail.com"
           git config --global user.name "nkmr-jp"
           npm run sync-version


### PR DESCRIPTION
## Summary
- Fix npm publish failure caused by `NODE_AUTH_TOKEN` conflicting with OIDC trusted publishing
- `actions/setup-node` with `registry-url` creates `.npmrc` referencing `NODE_AUTH_TOKEN`, which takes precedence over OIDC

## Root Cause
The previous CI run ([#22523515260](https://github.com/nkmr-jp/api-to-go/actions/runs/22523515260)) showed:
```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
npm notice Access token expired or revoked.
```
An old/invalid `NODE_AUTH_TOKEN` was being used instead of OIDC authentication.

## Fix
- Clear `.npmrc` (`rm -f "$NPM_CONFIG_USERCONFIG"`) before `npm publish`
- Explicitly set `NODE_AUTH_TOKEN: ''` to prevent any secret from being injected

## Additional Recommendation
Delete the `NPM_TOKEN` secret from repository settings (Settings > Secrets > Actions) since it is no longer needed with OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)